### PR TITLE
Gold infopanel update fix

### DIFF
--- a/Assets/Scripts/Game/Entities/PlayerEntity.cs
+++ b/Assets/Scripts/Game/Entities/PlayerEntity.cs
@@ -153,7 +153,7 @@ namespace DaggerfallWorkshop.Game.Entity
         public uint TimeOfLastSkillTraining { get { return timeOfLastSkillTraining; } set { timeOfLastSkillTraining = value; } }
         public uint TimeOfLastStealthCheck { get { return timeOfLastStealthCheck; } set { timeOfLastStealthCheck = value; } }
         public int StartingLevelUpSkillSum { get { return startingLevelUpSkillSum; } set { startingLevelUpSkillSum = value; } }
-        public int CurrentLevelUpSkillSum { get { return currentLevelUpSkillSum; } }
+        public int CurrentLevelUpSkillSum { get { return currentLevelUpSkillSum; } internal set { currentLevelUpSkillSum = value; } }
         public bool ReadyToLevelUp { get { return readyToLevelUp; } set { readyToLevelUp = value; } }
         public bool OghmaLevelUp { get { return oghmaLevelUp; } set { oghmaLevelUp = value; } }
         public short[] SGroupReputations { get { return sGroupReputations; } set { sGroupReputations = value; } }

--- a/Assets/Scripts/Game/Items/ItemBuilder.cs
+++ b/Assets/Scripts/Game/Items/ItemBuilder.cs
@@ -810,6 +810,7 @@ namespace DaggerfallWorkshop.Game.Items
         {
             DaggerfallUnityItem newItem = CreateItem(ItemGroups.Currency, (int)Currency.Gold_pieces);
             newItem.stackCount = amount;
+            newItem.value = 1;
 
             return newItem;
         }

--- a/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
+++ b/Assets/Scripts/Game/Serialization/SerializableGameObject.cs
@@ -170,6 +170,7 @@ namespace DaggerfallWorkshop.Game.Serialization
         public uint timeOfLastSkillIncreaseCheck;
         public uint[] skillsRecentlyRaised;
         public int startingLevelUpSkillSum;
+        public int currentLevelUpSkillSum;
         public ulong[] equipTable;
         public ItemData_v1[] items;
         public ItemData_v1[] wagonItems;

--- a/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
+++ b/Assets/Scripts/Game/Serialization/SerializablePlayer.cs
@@ -125,6 +125,7 @@ namespace DaggerfallWorkshop.Game.Serialization
             data.playerEntity.skillsRecentlyRaised = entity.SkillsRecentlyRaised;
             data.playerEntity.timeOfLastSkillTraining = entity.TimeOfLastSkillTraining;
             data.playerEntity.startingLevelUpSkillSum = entity.StartingLevelUpSkillSum;
+            data.playerEntity.currentLevelUpSkillSum = entity.CurrentLevelUpSkillSum;
             data.playerEntity.equipTable = entity.ItemEquipTable.SerializeEquipTable();
             data.playerEntity.items = entity.Items.SerializeItems();
             data.playerEntity.wagonItems = entity.WagonItems.SerializeItems();
@@ -281,6 +282,8 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.TimeOfLastSkillIncreaseCheck = data.playerEntity.timeOfLastSkillIncreaseCheck;
             entity.TimeOfLastSkillTraining = data.playerEntity.timeOfLastSkillTraining;
             entity.StartingLevelUpSkillSum = data.playerEntity.startingLevelUpSkillSum;
+            if ((entity.CurrentLevelUpSkillSum = data.playerEntity.currentLevelUpSkillSum) == 0)
+                entity.SetCurrentLevelUpSkillSum();
             entity.Items.DeserializeItems(data.playerEntity.items);
             entity.WagonItems.DeserializeItems(data.playerEntity.wagonItems);
             entity.OtherItems.DeserializeItems(data.playerEntity.otherItems);
@@ -302,7 +305,6 @@ namespace DaggerfallWorkshop.Game.Serialization
             entity.LastTimePlayerAteOrDrankAtTavern = data.playerEntity.lastTimePlayerAteOrDrankAtTavern;
             entity.CrimeCommitted = data.playerEntity.crimeCommitted;
             entity.HaveShownSurrenderToGuardsDialogue = data.playerEntity.haveShownSurrenderToGuardsDialogue;
-            entity.SetCurrentLevelUpSkillSum();
             if (DaggerfallUnity.Settings.PlayerTorchFromItems)
                 entity.LightSource = entity.Items.GetItem(data.playerEntity.lightSourceUID);
             entity.SGroupReputations[(int)FactionFile.SocialGroups.Commoners] = data.playerEntity.reputationCommoners;

--- a/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
+++ b/Assets/Scripts/Game/UserInterfaceWindows/DaggerfallInventoryWindow.cs
@@ -484,6 +484,8 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
 
             goldButton = DaggerfallUI.AddButton(goldButtonRect, NativePanel);
             goldButton.OnMouseClick += GoldButton_OnMouseClick;
+            if (itemInfoPanel != null)
+                goldButton.OnMouseEnter += GoldButton_OnMouseEnter;
         }
 
         protected void SetupAccessoryElements()
@@ -2024,6 +2026,15 @@ namespace DaggerfallWorkshop.Game.UserInterfaceWindows
         protected virtual void ItemListScroller_OnHover(DaggerfallUnityItem item)
         {
             UpdateItemInfoPanel(item);
+        }
+
+        protected virtual void GoldButton_OnMouseEnter(BaseScreenComponent sender)
+        {
+            // UpdateItemInfoPanel wants a item, so temporarily reify gold
+            int playerGold = GameManager.Instance.PlayerEntity.GoldPieces;
+            DaggerfallUnityItem goldPieces = ItemBuilder.CreateGoldPieces(playerGold);
+            UpdateItemInfoPanel(goldPieces);
+
         }
 
         protected virtual void StartGameBehaviour_OnNewGame()


### PR DESCRIPTION
This sets the value of a gold piece, in gold pieces, to 1, which fixes the value display in the info panel and generally seems more correct than having it as zero. However, I'm not sure what other side-effect this might have.